### PR TITLE
FP-40 show notes on the right menu

### DIFF
--- a/src/FilePocket.Application/Services/FileService.cs
+++ b/src/FilePocket.Application/Services/FileService.cs
@@ -84,6 +84,7 @@ public class FileService(
             CreatedAt = fileMetadata.CreatedAt,
             UpdatedAt = fileMetadata.UpdatedAt,
             PocketId = fileMetadata.PocketId,
+            FolderId = fileMetadata.FolderId,
             FileSize = fileMetadata.FileSize,
             FileType = fileMetadata.FileType,
             OriginalName = fileMetadata.OriginalName,

--- a/src/FilePocket.Application/Services/FileService.cs
+++ b/src/FilePocket.Application/Services/FileService.cs
@@ -33,6 +33,7 @@ public class FileService(
 
         return result;
     }
+    
     public async Task<IEnumerable<FileResponseModel>> GetAllFilesWithSoftDeletedAsync(Guid userId, Guid pocketId)
     {
         var fileMetadata = await repository.FileMetadata.GetAllWithSoftDeletedAsync(userId, pocketId);
@@ -385,7 +386,7 @@ public class FileService(
                 cancellationToken) ?? throw new AccountConsumptionNotFoundException(note.UserId);
 
             var newFileSizeInMbs = ((long)contentBytes.Length).ToMegabytes();
-            var sizeChangeInMbs = newFileSizeInMbs - ((long)fileMetadata.FileSize).ToMegabytes();
+            var sizeChangeInMbs = newFileSizeInMbs - fileMetadata.FileSize;
 
             if (storageConsumption.RemainingSizeMb < sizeChangeInMbs)
             {

--- a/src/FilePocket.BlazorClient/Features/Files/Models/FileTypes.cs
+++ b/src/FilePocket.BlazorClient/Features/Files/Models/FileTypes.cs
@@ -12,5 +12,6 @@
         Archive,
         Code,
         Font,
+        Note,
     }
 }

--- a/src/FilePocket.BlazorClient/Layout/MainLayout.razor
+++ b/src/FilePocket.BlazorClient/Layout/MainLayout.razor
@@ -233,7 +233,7 @@
 
                         <div class="progressBar-body">
                             <div class="progressBar-occupied" style="width:@(_occupiedStorageSpacePercentage)%"></div>
-                            <div class="progressBar-free-space" style="width:@(_unoccupiedStorageSpacePercentage)%"></div>
+                            @* <div class="progressBar-free-space" style="width:@(_unoccupiedStorageSpacePercentage)%"></div> *@
                         </div>
                         @if (_storageConsumption.Used<100)
                         {
@@ -248,7 +248,10 @@
                             @foreach (var item in StorageItems)
                             {
                                 <div class="d-flex align-items-center mb-2">
-                                    <div class="icon-box" style="background-color:@item.Color">
+                                    <div class="icon-box" style="background-color:@item.Color; 
+                                                                width:24px; 
+                                                                text-align:center;
+                                                                border-radius:3px">
                                         <i class="@item.Icon"></i>
                                     </div>
                                     <span class="ms-2 flex-grow-1">@item.Name</span>
@@ -307,12 +310,13 @@
 
     private List<StorageItem> StorageItems = new()
     {
-        new StorageItem("Documents", 0.0, "#FEE6AC", "bi bi-folder"),
+        new StorageItem("Documents", 0.0, "#E9BE26", "bi bi-folder"),
         new StorageItem("Books", 0.0, "#699CFF", "bi bi-book"),
         new StorageItem("Music", 0.0, "#47A3BC", "bi bi-file-music"),
         new StorageItem("Pictures", 0.0, "#F7B169", "bi bi-image"),
         new StorageItem("Videos", 0.0, "#AC91DA", "bi bi-film"),
-        new StorageItem("Other", 0.0, "#CFE6F3", "bi bi-file-earmark"),
+        new StorageItem("Notes", 0.0, "#FD7C9B", "bi bi-pencil-square"),
+        new StorageItem("Other", 0.0, "#88BFDE", "bi bi-file-earmark"),
     };
 
     private class StorageItem

--- a/src/FilePocket.BlazorClient/Layout/MainLayout.razor.cs
+++ b/src/FilePocket.BlazorClient/Layout/MainLayout.razor.cs
@@ -191,6 +191,9 @@ public partial class MainLayout : IDisposable
                 case FileTypes.Video:
                     _occupiedSpaceByFileType[FileTypes.Video] += file.FileSize;
                     break;
+                case FileTypes.Note:
+                    _occupiedSpaceByFileType[FileTypes.Note] += file.FileSize;
+                    break;
                 default:
                     _occupiedSpaceByFileType[FileTypes.Other] += file.FileSize;
                     break;
@@ -223,6 +226,9 @@ public partial class MainLayout : IDisposable
                 case "Videos":
                     item.Size = _occupiedSpaceByFileType[FileTypes.Video];
                     break;
+                case "Notes":
+                    item.Size = _occupiedSpaceByFileType[FileTypes.Note];
+                    break;
                 case "Other":
                     item.Size = _occupiedSpaceByFileType[FileTypes.Other];
                     break;
@@ -239,6 +245,7 @@ public partial class MainLayout : IDisposable
             _occupiedSpaceByFileType[FileTypes.Audio],
             _occupiedSpaceByFileType[FileTypes.Image],
             _occupiedSpaceByFileType[FileTypes.Video],
+            _occupiedSpaceByFileType[FileTypes.Note],
             _occupiedSpaceByFileType[FileTypes.Other]
             );
     }
@@ -252,6 +259,7 @@ public partial class MainLayout : IDisposable
             {FileTypes.Audio, 0.0},
             {FileTypes.Image, 0.0},
             {FileTypes.Video, 0.0},
+            {FileTypes.Note, 0.0},
             {FileTypes.Other, 0.0},
         };
     }

--- a/src/FilePocket.BlazorClient/MyComponents/NotesAndFolders.razor.cs
+++ b/src/FilePocket.BlazorClient/MyComponents/NotesAndFolders.razor.cs
@@ -33,7 +33,6 @@ namespace FilePocket.BlazorClient.MyComponents
         [Inject]
         private IPocketRequests PocketRequests { get; set; } = default!;
 
-
         [Inject]
         private ITrashRequests TrashRequests { get; set; } = default!;
 

--- a/src/FilePocket.BlazorClient/MyComponents/NotesEditor.razor.cs
+++ b/src/FilePocket.BlazorClient/MyComponents/NotesEditor.razor.cs
@@ -17,11 +17,11 @@ namespace FilePocket.BlazorClient.MyComponents
         private DotNetObjectReference<NotesEditor>? _editorRef;
         private readonly string _editorId = $"NotesEditor-{Guid.NewGuid()}";
 
-        protected override void OnParametersSet()
+        protected override async Task  OnParametersSetAsync()
         {
               _editorRef ??= DotNetObjectReference.Create(this);
 
-            base.OnParametersSet();
+            await base.OnParametersSetAsync();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -40,8 +40,6 @@ namespace FilePocket.BlazorClient.MyComponents
         [JSInvokable]
         public async Task OnSave(string content)
         {
-            Console.WriteLine($"Content saved: {content}");
-
             await OnSaveOrUpdate.Invoke(content);
         }
 

--- a/src/FilePocket.BlazorClient/Pages/Notes/CreateOrEditNote.razor.cs
+++ b/src/FilePocket.BlazorClient/Pages/Notes/CreateOrEditNote.razor.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Components;
 using FilePocket.BlazorClient.Features.Notes.Models;
 using Microsoft.AspNetCore.Components.Web;
 using FilePocket.BlazorClient.Features;
+using FilePocket.BlazorClient.Features.Storage.Requests;
+using FilePocket.BlazorClient.Features.Storage.Models;
+using FilePocket.BlazorClient.Helpers;
 
 namespace FilePocket.BlazorClient.Pages.Notes
 {
@@ -30,6 +33,12 @@ namespace FilePocket.BlazorClient.Pages.Notes
 
         [Inject]
         private IUserRequests UserRequests { get; set; } = default!;
+
+        [Inject] 
+        private IStorageRequests StorageRequests { get; set; } = default!;
+
+        [Inject] 
+        private StateContainer<StorageConsumptionModel> StorageStateContainer { get; set; } = default!;
 
         [Inject]
         private NavigationHistoryService NavigationHistory { get; set; } = default!;
@@ -118,6 +127,9 @@ namespace FilePocket.BlazorClient.Pages.Notes
         {
             _note!.Content = content;
             await SaveOrUpdateNote();
+
+            var storageConsumption = await StorageRequests.GetStorageConsumption();
+            StorageStateContainer.SetValue(storageConsumption!);
         }
 
         private async Task SaveOrUpdateNote()

--- a/src/FilePocket.BlazorClient/wwwroot/css/progressBar.css
+++ b/src/FilePocket.BlazorClient/wwwroot/css/progressBar.css
@@ -9,12 +9,14 @@
     height: .25rem;
     overflow: hidden;
     margin-bottom: 10px;
+    border-radius: 0.125rem;
+    background-color: var(--dt-surface-variant,rgb(241,243,244));
 }
 .progressBar-occupied {
-    background-color: var(--dt-primary,rgb(26,115,232))
+    background-color: var(--dt-primary,rgb(26,115,232));
+    border-radius: 0 0.125rem 0.125rem 0;
 }
 
 .progressBar-free-space {
     background-color: var(--dt-surface-variant,rgb(241,243,244));
-    border-radius: 3px
 }


### PR DESCRIPTION
1. Add Notes type to space consumption categories
2. Update styles for file type icons
3. Change markup for space consumption progress bar
4. Fix bug with losing folderId when editing a Note
5. Fix bug with Note size change on update
